### PR TITLE
Update ILI9341_TFT_LCD_basic.ino

### DIFF
--- a/Arduino_package/hardware/libraries/SPI/examples/ILI9341_TFT_LCD_basic/ILI9341_TFT_LCD_basic.ino
+++ b/Arduino_package/hardware/libraries/SPI/examples/ILI9341_TFT_LCD_basic/ILI9341_TFT_LCD_basic.ino
@@ -29,6 +29,10 @@
 #define TFT_RESET       8
 #define TFT_DC          13
 #define TFT_CS          12
+#elif defined(BOARD_RTL8720DN_BW16)
+#define TFT_RESET       2
+#define TFT_DC          8
+#define TFT_CS          9
 #endif
 
 AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);


### PR DESCRIPTION
**PR to ambd_arduino dev branch**
- Add line 32-35 board SPI Pins (RST, CS, DC) definition for RTL8720DN_BW16
- This code has been verified using the BW16 development board on v3.0.8 and v3.0.9 early released Arduino SDK.