### PR TITLE
Change INPUT_PULLNONE to INPUT

### DIFF
--- a/Arduino_package/hardware/cores/arduino/wiring_digital.c
+++ b/Arduino_package/hardware/cores/arduino/wiring_digital.c
@@ -98,12 +98,12 @@ void pinMode(uint32_t ulPin, uint32_t ulMode)
 
     switch (ulMode)
     {
-        case INPUT:
+        case INPUT_PULLDOWN:
             gpio_dir((gpio_t *)pGpio_t, PIN_INPUT);
             gpio_mode((gpio_t *)pGpio_t, PullDown);
             break;
 
-        case INPUT_PULLNONE:
+        case INPUT:
             gpio_dir((gpio_t *)pGpio_t, PIN_INPUT);
             gpio_mode((gpio_t *)pGpio_t, PullNone);
             break;


### PR DESCRIPTION
By observing the behavior with 328p, the INPUT behavior is set to "High Impedance", which acts the same as INPUT_PULLNONE in amebaD.
To match this, change INPUT_PULLNONE to INPUT.
Also, change currently INPUT to INPUT_PULLDOWN since its still useful.

Important: this might change many default behaviors, needs to test it fully or leave it untouched.