### PR TITLE
Fix for iPhone hotspot SSIDs

### DIFF
--- a/Arduino_package/hardware/libraries/WiFi/examples/ConnectWithWiFi/ConnectNoEncryption/ConnectNoEncryption.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/ConnectWithWiFi/ConnectNoEncryption/ConnectNoEncryption.ino
@@ -14,6 +14,14 @@
  */
 #include <WiFi.h>
 
+// If you are connecting to an iPhone WiFi hotspot, the default SSID uses Unicode (U+2019) Right Single Quotation Mark instead of ASCII apostrophe
+// Modify the "Your Name" section in the SSID below to connect to an iPhone using a default SSID style
+// char ssid[] = "Your Name\xE2\x80\x99s iPhone";
+
+// UTF-8 encoding can also be used for SSID with emoji characters
+// Emoji characters can be converted into UTF-8 at https://mothereff.in/utf-8
+// char ssid[] = "\xe2\x9c\x8c\xef\xb8\x8f Ameba \xe2\x9c\x8c\xef\xb8\x8f";
+
 char ssid[] = "yourNetwork";     // the name of your network
 int status = WL_IDLE_STATUS;     // the Wifi radio's status
 

--- a/Arduino_package/hardware/libraries/WiFi/examples/ConnectWithWiFi/ConnectWithWEP/ConnectWithWEP.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/ConnectWithWiFi/ConnectWithWEP/ConnectWithWEP.ino
@@ -27,6 +27,14 @@
 // 0: Exactly 10 or 26 hexadecimal characters; 1:Exactly 5 or 13 ASCII characters
 #define password_type                           0
 
+// If you are connecting to an iPhone WiFi hotspot, the default SSID uses Unicode (U+2019) Right Single Quotation Mark instead of ASCII apostrophe
+// Modify the "Your Name" section in the SSID below to connect to an iPhone using a default SSID style
+// char ssid[] = "Your Name\xE2\x80\x99s iPhone";
+
+// UTF-8 encoding can also be used for SSID with emoji characters
+// Emoji characters can be converted into UTF-8 at https://mothereff.in/utf-8
+// char ssid[] = "\xe2\x9c\x8c\xef\xb8\x8f Ameba \xe2\x9c\x8c\xef\xb8\x8f";
+
 char ssid[] = "yourNetwork";                    // your network SSID (name)
 int keyIndex = 0;                               // your network key Index number
 #if (password_type == 0)

--- a/Arduino_package/hardware/libraries/WiFi/examples/ConnectWithWiFi/ConnectWithWPA/ConnectWithWPA.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/ConnectWithWiFi/ConnectWithWPA/ConnectWithWPA.ino
@@ -14,6 +14,14 @@
  */
 #include <WiFi.h>
 
+// If you are connecting to an iPhone WiFi hotspot, the default SSID uses Unicode (U+2019) Right Single Quotation Mark instead of ASCII apostrophe
+// Modify the "Your Name" section in the SSID below to connect to an iPhone using a default SSID style
+// char ssid[] = "Your Name\xE2\x80\x99s iPhone";
+
+// UTF-8 encoding can also be used for SSID with emoji characters
+// Emoji characters can be converted into UTF-8 at https://mothereff.in/utf-8
+// char ssid[] = "\xe2\x9c\x8c\xef\xb8\x8f Ameba \xe2\x9c\x8c\xef\xb8\x8f";
+
 char ssid[] = "yourNetwork";     //  your network SSID (name)
 char pass[] = "secretPassword";  // your network password
 int status = WL_IDLE_STATUS;     // the Wifi radio's status

--- a/Arduino_package/hardware/libraries/WiFi/examples/WiFiAPMode/WiFiAPMode.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/WiFiAPMode/WiFiAPMode.ino
@@ -1,5 +1,9 @@
 #include <WiFi.h>
 
+// UTF-8 encoding can also be used for SSID with emoji characters
+// Emoji characters can be converted into UTF-8 at https://mothereff.in/utf-8
+// char ssid[] = "\xe2\x9c\x8c\xef\xb8\x8f Ameba \xe2\x9c\x8c\xef\xb8\x8f";
+
 char ssid[] = "yourNetwork";  //Set the AP's SSID
 char pass[] = "Password";     //Set the AP's password
 char channel[] = "1";         //Set the AP's channel


### PR DESCRIPTION
add in examples for using UTF-8 encoding to connect to iPhone hotspots using non-ASCII SSID