### PR TITLE
Update line117 osPriority in main.cpp to dev branch

### DIFF
--- a/Arduino_package/hardware/cores/ambd/main.cpp
+++ b/Arduino_package/hardware/cores/ambd/main.cpp
@@ -114,7 +114,7 @@ int main(void)
     PAD_PullCtrl(_PB_3, GPIO_PuPd_NOPULL);
 
 #if 1
-    osThreadDef(main_task, osPriorityRealtime, 1, MAIN_THREAD_STACK_SIZE);
+    osThreadDef(main_task, osPriorityNormal, 1, MAIN_THREAD_STACK_SIZE);
     main_tid = osThreadCreate(osThread(main_task), NULL);
 
     osKernelStart();


### PR DESCRIPTION
Update line 117 RTOS priority from osPriorityRealtime decrease to osPriorityNormal.

Tested the following examples that this fix might not affect the function of other peripherals:
- Watchdog: “Watchdog Timer”
- WiFi: ” WiFiSSLClient “ 
- HTTP: "SimpleWebServerWiFi"
- MQTT: “MQTT_Basic”
- BLE: "BLE Scan"
- I2C: “LCD_HelloWorld”.
- SPI: "ILI9341_TFT_LCD_basic"
- UART: "Adafruit_GPS_parsing"