### PR TITLE
Update GPIO - Ultrasonic example pin number

### DIFF
--- a/Arduino_package/hardware/libraries/GPIO/examples/HCSR04_Ultrasonic/HCSR04_Ultrasonic.ino
+++ b/Arduino_package/hardware/libraries/GPIO/examples/HCSR04_Ultrasonic/HCSR04_Ultrasonic.ino
@@ -13,7 +13,7 @@
  **/
 
 const int trigger_pin = 12;
-const int echo_pin    = 13;
+const int echo_pin    = 11;
 
 void setup() {
     Serial.begin(115200);


### PR DESCRIPTION
Change the `echo_pin` to **pin 11** as BW16 does not have pin 13.