### PR TITLE
Update GPIO pin number for GPIO examples

### DIFF
--- a/Arduino_package/hardware/libraries/GPIO/examples/HCSR04_Ultrasonic/HCSR04_Ultrasonic.ino
+++ b/Arduino_package/hardware/libraries/GPIO/examples/HCSR04_Ultrasonic/HCSR04_Ultrasonic.ino
@@ -13,7 +13,7 @@
  **/
 
 const int trigger_pin = 12;
-const int echo_pin    = 13;
+const int echo_pin    = 11;
 
 void setup() {
     Serial.begin(115200);

--- a/Arduino_package/hardware/libraries/GPIO/examples/LED_InterruptCtrl/LED_InterruptCtrl.ino
+++ b/Arduino_package/hardware/libraries/GPIO/examples/LED_InterruptCtrl/LED_InterruptCtrl.ino
@@ -9,7 +9,7 @@
 */
 
 int button = 12;
-int led    = 13;
+int led    = 11;
 
 int ledState = 1;
 


### PR DESCRIPTION
- Change pin 13 to pin 11 for the following examples as BW16 does not have pin 13:

1. GPIO - Ultrasonic module
2. GPIO - LED interrupt control 