### PR TITLE
Enable lwip non-blocking mode in ard_socket.c

### DIFF
--- a/Arduino_package/hardware/cores/ambd/Arduino.h
+++ b/Arduino_package/hardware/cores/ambd/Arduino.h
@@ -32,8 +32,6 @@
 
 #ifdef __cplusplus
 #include <string>
-#define _min(a,b) ((a)<(b)?(a):(b))
-#define _max(a,b) ((a)>(b)?(a):(b))
 #endif // __cplusplus
 
 #include <stdio.h>

--- a/Arduino_package/hardware/cores/ambd/Arduino.h
+++ b/Arduino_package/hardware/cores/ambd/Arduino.h
@@ -29,6 +29,13 @@
 
 //#define Arduino_STD_PRINTF
 #ifdef Arduino_STD_PRINTF
+
+#ifdef __cplusplus
+#include <string>
+#define _min(a,b) ((a)<(b)?(a):(b))
+#define _max(a,b) ((a)>(b)?(a):(b))
+#endif // __cplusplus
+
 #include <stdio.h>
 #endif
 

--- a/Arduino_package/hardware/cores/ambd/ard_socket.c
+++ b/Arduino_package/hardware/cores/ambd/ard_socket.c
@@ -203,7 +203,8 @@ int start_server(uint16_t port, uint8_t protMode) {
         printf("\r\nERROR on binding\r\n");
         return -1;
     }
-
+    lwip_fcntl(_sock, F_SETFL, O_NONBLOCK);
+	
     return _sock;
 }
 
@@ -243,7 +244,8 @@ int start_server_v6(uint16_t port, uint8_t protMode) {
         return -1;
     }
     printf("\n\r[INFO] Bind socket successfully\n");
-
+    lwip_fcntl(_sock, F_SETFL, O_NONBLOCK);
+	
     return _sock;
 }
 

--- a/Arduino_package/hardware/cores/ambd/ard_socket.c
+++ b/Arduino_package/hardware/cores/ambd/ard_socket.c
@@ -243,9 +243,9 @@ int start_server_v6(uint16_t port, uint8_t protMode) {
         closesocket(_sock);
         return -1;
     }
-    printf("\n\r[INFO] Bind socket successfully\n");
     lwip_fcntl(_sock, F_SETFL, O_NONBLOCK);
-	
+    printf("\n\r[INFO] Bind socket successfully\n");
+   
     return _sock;
 }
 

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.cpp
@@ -49,12 +49,14 @@ int WiFiClient::available() {
         return 0;
     }
     if (_sock >= 0) {
+try_again:
         ret = clientdrv.availData(_sock);
         if (ret > 0) {
             return 1;
         } else {
             err = clientdrv.getLastErrno(_sock);
-            if ( !((err == 0) || (err == EAGAIN)) ) {
+            if (err == EAGAIN) goto try_again;
+            if (err == 0) {
                 _is_connected = false;
             }
             return 0;


### PR DESCRIPTION
Add `lwip_fcntl(_sock, F_SETFL, O_NONBLOCK);` in `start_server()` and `start_server_v6()` to enable lwip non-blocking mode.

-------

### Remarks
**Thanks for Ameba Arduino user @jojoling's help with raising this bug and providing the solution.

#### How to reproduce this bug?
Add in any code after WiFiWebServer.ino line 89: (For example: `Serial.println("abc");`)**
https://github.com/ambiot/ambd_arduino/blob/2e8a9df1f8a297cc643e858b42204908e391addf/Arduino_package/hardware/libraries/WiFi/examples/WiFiWebServer/WiFiWebServer.ino#L89

After the example is uploaded to the board and running, while no client is connecting to the Ameba board, the added line will never be able to be printed in the serial monitor. 

#### Provided solution
This is due to lwip's default running in "blocking" mode. Adding `lwip_fcntl(_sock, F_SETFL, O_NONBLOCK);` in `start_server()` and `start_server_v6()` to enable lwip non-blocking mode.