### PR TITLE
Modify typo in WiFi API

### DIFF
--- a/Arduino_package/hardware/cores/ambd/wifi_drv.cpp
+++ b/Arduino_package/hardware/cores/ambd/wifi_drv.cpp
@@ -521,7 +521,7 @@ uint8_t WiFiDrv::getScanNetworks()
     return _networkCount;
 }
 
-char* WiFiDrv::getSSIDNetoworks(uint8_t networkItem)
+char* WiFiDrv::getSSIDNetworks(uint8_t networkItem)
 {
     if (networkItem >= WL_NETWORKS_LIST_MAXNUM) {
         return NULL;

--- a/Arduino_package/hardware/cores/ambd/wifi_drv.cpp
+++ b/Arduino_package/hardware/cores/ambd/wifi_drv.cpp
@@ -558,7 +558,7 @@ uint32_t WiFiDrv::getEncTypeNetowrksEx(uint8_t networkItem)
     return ((networkItem >= WL_NETWORKS_LIST_MAXNUM) ? 0 : _networkEncr[networkItem]);
 }
 
-int32_t WiFiDrv::getRSSINetoworks(uint8_t networkItem)
+int32_t WiFiDrv::getRSSINetworks(uint8_t networkItem)
 {
     if (networkItem >= WL_NETWORKS_LIST_MAXNUM) {
         //return NULL;

--- a/Arduino_package/hardware/cores/ambd/wifi_drv.h
+++ b/Arduino_package/hardware/cores/ambd/wifi_drv.h
@@ -235,7 +235,7 @@ class WiFiDrv
          *
          * return: ssid string of the specified item on the networks scanned list
          */
-        static char* getSSIDNetoworks(uint8_t networkItem);
+        static char* getSSIDNetworks(uint8_t networkItem);
 
         /*
          * Return the RSSI of the networks discovered during the scanNetworks
@@ -244,7 +244,7 @@ class WiFiDrv
          *
          * return: signed value of RSSI of the specified item on the networks scanned list
          */
-        static int32_t getRSSINetoworks(uint8_t networkItem);
+        static int32_t getRSSINetworks(uint8_t networkItem);
 
         /*
          * Return the encryption type of the networks discovered during the scanNetworks

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFi.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFi.cpp
@@ -167,7 +167,7 @@ char* WiFiClass::SSID(uint8_t networkItem)
 
 int32_t WiFiClass::RSSI(uint8_t networkItem)
 {
-    return WiFiDrv::getRSSINetoworks(networkItem);
+    return WiFiDrv::getRSSINetworks(networkItem);
 }
 
 uint8_t WiFiClass::encryptionType(uint8_t networkItem)

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFi.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFi.cpp
@@ -162,7 +162,7 @@ int8_t WiFiClass::scanNetworks()
 
 char* WiFiClass::SSID(uint8_t networkItem)
 {
-    return WiFiDrv::getSSIDNetoworks(networkItem);
+    return WiFiDrv::getSSIDNetworks(networkItem);
 }
 
 int32_t WiFiClass::RSSI(uint8_t networkItem)


### PR DESCRIPTION
Modify typo in WiFi API:
- Update `getSSIDNetoworks` to `getSSIDNetworks`
- Update `getRSSINetoworks` to `getRSSINetworks`