### PR TITLE
Fix issue (#131) - part 2 - add missing macro to improve compatibility

### DIFF
--- a/Arduino_package/hardware/variants/awcu488_thingplus/variant.h
+++ b/Arduino_package/hardware/variants/awcu488_thingplus/variant.h
@@ -47,6 +47,8 @@ extern void wait_for_debug(void);
 #define TOTAL_GPIO_PIN_NUM                      (30)
 #define TOTAL_PWM_PIN_NUM                       (11)
 
+#define digitalPinToInterrupt(p)    (((p)<TOTAL_GPIO_PIN_NUM)?(p):-1)
+
 /* Digital pin mapping refer to g_APinDescription */
 #define AMB_D0                                  0  // PA_18
 #define AMB_D1                                  1  // PA_16

--- a/Arduino_package/hardware/variants/rtl8720dn_bw16/variant.h
+++ b/Arduino_package/hardware/variants/rtl8720dn_bw16/variant.h
@@ -47,6 +47,8 @@ extern void wait_for_debug(void);
 #define TOTAL_GPIO_PIN_NUM                      (13)
 #define TOTAL_PWM_PIN_NUM                       (4)
 
+#define digitalPinToInterrupt(p)    (((p)<TOTAL_GPIO_PIN_NUM)?(p):-1)
+
 /* Digital pin mapping refer to g_APinDescription */
 #define AMB_D0                                  0  // PA_7
 #define AMB_D1                                  1  // PA_8

--- a/Arduino_package/hardware/variants/rtl8722dm/variant.h
+++ b/Arduino_package/hardware/variants/rtl8722dm/variant.h
@@ -47,6 +47,8 @@ extern void wait_for_debug(void);
 #define TOTAL_GPIO_PIN_NUM                      (29)
 #define TOTAL_PWM_PIN_NUM                       (13)
 
+#define digitalPinToInterrupt(p)    (((p)<TOTAL_GPIO_PIN_NUM)?(p):-1)
+
 /* Digital pin mapping refer to g_APinDescription */
 #define AMB_D0                                  0  // PB_2
 #define AMB_D1                                  1  // PB_1

--- a/Arduino_package/hardware/variants/rtl8722dm_mini/variant.h
+++ b/Arduino_package/hardware/variants/rtl8722dm_mini/variant.h
@@ -47,6 +47,8 @@ extern void wait_for_debug(void);
 #define TOTAL_GPIO_PIN_NUM                      (29)
 #define TOTAL_PWM_PIN_NUM                       (9)
 
+#define digitalPinToInterrupt(p)    (((p)<TOTAL_GPIO_PIN_NUM)?(p):-1)
+
 /* Digital pin mapping refer to g_APinDescription */
 #define AMB_D0                                  0  // PB_0
 #define AMB_D1                                  1  // PB_1


### PR DESCRIPTION
- Fix compilation error with issue (#131)
- Update variant.h in all boards to add a missing macro

Verification:
- Tested against WiFiSSLClient and Blink example and passed