### PR TITLE
Update TFT LCD example SPI_BUS

### DIFF
--- a/Arduino_package/hardware/libraries/SPI/examples/ILI9341_TFT_LCD_PM2.5/ILI9341_TFT_LCD_PM2.5.ino
+++ b/Arduino_package/hardware/libraries/SPI/examples/ILI9341_TFT_LCD_PM2.5/ILI9341_TFT_LCD_PM2.5.ino
@@ -34,7 +34,7 @@ SoftwareSerial mySerial(SERIAL1_RX, SERIAL1_TX); // RX, TX
 #define TFT_RESET       4
 #define TFT_DC          5
 #define TFT_CS          SPI_SS
-#define SPI_BUS         SPI0
+#define SPI_BUS         SPI
 
 AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET, SPI_BUS);
 


### PR DESCRIPTION
- Amend default SPI_BUS in ILI9341_TFT_LCD_PM2.5.ino to SPI instead of SPI0
