### PR TITLE
Update postbuild_img2_arduino_macos.cpp

### DIFF
--- a/Arduino_package/ameba_d_tools_macos/tools/macos/src/postbuild_img2_arduino_macos.cpp
+++ b/Arduino_package/ameba_d_tools_macos/tools/macos/src/postbuild_img2_arduino_macos.cpp
@@ -3,6 +3,7 @@
 Compile:
 
 macos:
+g++ -o tools/macos/postbuild_img2_arduino_macos tools/macos/src/postbuild_img2_arduino_macos.cpp
 g++ -mmacosx-version-min=11.0 -o tools/macos/postbuild_img2_arduino_macos tools/macos/src/postbuild_img2_arduino_macos.cpp
 
 */

--- a/Arduino_package/ameba_d_tools_macos/tools/macos/src/postbuild_img2_arduino_macos.cpp
+++ b/Arduino_package/ameba_d_tools_macos/tools/macos/src/postbuild_img2_arduino_macos.cpp
@@ -3,7 +3,7 @@
 Compile:
 
 macos:
-g++ -o tools/macos/postbuild_img2_arduino_macos tools/macos/src/postbuild_img2_arduino_macos.cpp
+g++ -mmacosx-version-min=11.0 -o tools/macos/postbuild_img2_arduino_macos tools/macos/src/postbuild_img2_arduino_macos.cpp
 
 */
 


### PR DESCRIPTION
Update compile arguments to retain support for macOS 11