### PR TITLE
Add in destructors for all Wi-Fi Classes

### DIFF
--- a/Arduino_package/hardware/cores/ambd/server_drv.cpp
+++ b/Arduino_package/hardware/cores/ambd/server_drv.cpp
@@ -28,7 +28,7 @@ int ServerDrv::startClientV6(const char *ipv6Address, uint16_t port, uint8_t por
 int ServerDrv::startClientv6(uint32_t *ipv6Address, uint16_t port, uint8_t portMode) {
     int sock;
     sock = start_clientv6(ipv6Address, port, portMode);
-    printf("\n\r[INFO]server_drv.cpp:  startClientv6() sock value: %x\n\r", sock);
+    printf("\n\r [INFO]server_drv.cpp:  startClientv6() sock value: %x\n\r", sock);
     return sock;
 }
 
@@ -36,6 +36,7 @@ int ServerDrv::startServer(uint16_t port, uint8_t portMode, bool blockMode) {
     int sock;
 
     if (blockMode) {
+        printf("\r\n[INFO] server_drv.cpp: WiFi server is set to blocking mode\r\n");
         if (getIPv6Status() == 0) {
             sock = start_server(port, portMode);
             if (sock >= 0) {
@@ -46,7 +47,6 @@ int ServerDrv::startServer(uint16_t port, uint8_t portMode, bool blockMode) {
             }
         } else {
             sock = start_server_v6(port, portMode);
-
             if (sock >= 0) {
                 if (portMode == TCP_MODE) {
                     //Make it listen to socket with max 20 connections
@@ -55,6 +55,7 @@ int ServerDrv::startServer(uint16_t port, uint8_t portMode, bool blockMode) {
             }
         }
     } else {
+        printf("\r\n[INFO] server_drv.cpp: WiFi server is set to non-blocking mode\r\n");
         if (getIPv6Status() == 0) {
             sock = start_server(port, portMode);
             set_nonblocking(sock);

--- a/Arduino_package/hardware/libraries/WiFi/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/WiFiWebServer/WiFiWebServer.ino
@@ -1,6 +1,8 @@
 /*
 
  Example guide:
+ https://www.amebaiot.com/en/amebad-arduino-web-server-status/
+ 
  */
 
 #include <WiFi.h>
@@ -41,10 +43,10 @@ void loop() {
     // listen for incoming clients
     WiFiClient client = server.available();
     if (client) {
-        Serial.println("new client");
         // an http request ends with a blank line
         boolean currentLineIsBlank = true;
         while (client.connected()) {
+            Serial.println("new client connected.");
             if (client.available()) {
                 char c = client.read();
                 Serial.write(c);
@@ -81,9 +83,12 @@ void loop() {
         delay(1);
 
         // close the connection:
-        client.stop();
+        // client.stop(); // remove this line since destructor will be called automatically
         Serial.println("client disonnected");
     }
+    // continue with user code in WiFi server non-blocking mode 
+    Serial.println("User code implementing here...");
+    delay(5000);
 }
 
 void printWifiStatus() {

--- a/Arduino_package/hardware/libraries/WiFi/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/WiFiWebServer/WiFiWebServer.ino
@@ -45,8 +45,8 @@ void loop() {
     if (client) {
         // an http request ends with a blank line
         boolean currentLineIsBlank = true;
+        Serial.println("new client");
         while (client.connected()) {
-            Serial.println("new client connected.");
             if (client.available()) {
                 char c = client.read();
                 Serial.write(c);

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFi.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFi.cpp
@@ -24,8 +24,9 @@
 #include "wifi_drv.h"
 #include "wiring.h"
 
-WiFiClass::WiFiClass() {
-}
+WiFiClass::WiFiClass() {}
+
+WiFiClass::~WiFiClass() {}
 
 void WiFiClass::init() {
     WiFiDrv::wifiDriverInit();

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFi.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFi.h
@@ -35,8 +35,7 @@ extern "C" {
 #include "WiFiSSLClient.h"
 #include "WiFiUdp.h"
 
-class WiFiClass
-{
+class WiFiClass {
     private:
         static void init();
     public:

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFi.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFi.h
@@ -41,6 +41,7 @@ class WiFiClass
         static void init();
     public:
         WiFiClass();
+        ~WiFiClass();
 
         /*
          * Get firmware version

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.cpp
@@ -52,13 +52,15 @@ int WiFiClient::available() {
         return 0;
     }
     if (_sock >= 0) {
-try_again:
+    try_again:
         ret = clientdrv.availData(_sock);
         if (ret > 0) {
             return 1;
         } else {
             err = clientdrv.getLastErrno(_sock);
-            if (err == EAGAIN) goto try_again;
+            if (err == EAGAIN) {
+                goto try_again;
+            }
             if (err != 0) {
                 _is_connected = false;
             }
@@ -87,7 +89,6 @@ int WiFiClient::read() {
             _is_connected = false;
         }
     }
-
     return ret;
 }
 
@@ -149,7 +150,6 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size) {
         _is_connected = false;
         return 0;
     }
-
     return size;
 }
 
@@ -238,7 +238,6 @@ int WiFiClient::setRecvTimeout(int timeout) {
         recvTimeout = timeout;
         clientdrv.setSockRecvTimeout(_sock, recvTimeout);
     }
-
     return 0;
 }
 

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.cpp
@@ -26,6 +26,10 @@ WiFiClient::WiFiClient(uint8_t sock) {
     recvTimeout = 3000;
 }
 
+WiFiClient::~WiFiClient() {
+    stop();
+}
+
 uint8_t WiFiClient::connected() {
     if ((_sock < 0) || (_sock == 0xFF)) {
         _is_connected = false;

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.h
@@ -43,7 +43,6 @@ class WiFiClient : public Client {
         ServerDrv clientdrv;
         bool _is_connected;
         uint8_t data[DATA_LENTH];
-
         int recvTimeout;
 };
 

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiClient.h
@@ -11,6 +11,7 @@ class WiFiClient : public Client {
     public:
         WiFiClient();
         WiFiClient(uint8_t sock);
+        ~WiFiClient();
 
         uint8_t status();
         virtual uint8_t connected();

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.cpp
@@ -44,6 +44,10 @@ WiFiSSLClient::WiFiSSLClient(uint8_t sock) {
     _sni_hostname = NULL;
 }
 
+WiFiSSLClient::~WiFiSSLClient() {
+   stop();
+}
+
 uint8_t WiFiSSLClient::connected() {
     if (sslclient.socket < 0) {
         _is_connected = false;

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.cpp
@@ -45,7 +45,7 @@ WiFiSSLClient::WiFiSSLClient(uint8_t sock) {
 }
 
 WiFiSSLClient::~WiFiSSLClient() {
-   stop();
+    stop();
 }
 
 uint8_t WiFiSSLClient::connected() {

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.h
@@ -8,7 +8,6 @@
 
 struct mbedtls_ssl_context;
 class WiFiSSLClient : public Client {
-
     public:
         WiFiSSLClient();
         WiFiSSLClient(uint8_t sock);

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiSSLClient.h
@@ -12,6 +12,7 @@ class WiFiSSLClient : public Client {
     public:
         WiFiSSLClient();
         WiFiSSLClient(uint8_t sock);
+        ~WiFiSSLClient();
 
         uint8_t status();
         virtual int connect(IPAddress ip, uint16_t port);

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.cpp
@@ -33,7 +33,7 @@ WiFiServer::WiFiServer(uint16_t port, tProtMode portMode) {
 }
 
 WiFiServer::~WiFiServer() {
-	close();
+    close();
 }
 
 void WiFiServer::begin() {

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.cpp
@@ -32,6 +32,10 @@ WiFiServer::WiFiServer(uint16_t port, tProtMode portMode) {
     _portMode = portMode;
 }
 
+WiFiServer::~WiFiServer() {
+	close();
+}
+
 void WiFiServer::begin() {
     _is_connected = false;
     _sock_ser = serverdrv.startServer(_port, _portMode, _is_blocked);
@@ -130,6 +134,7 @@ void WiFiServer::close() {
 
 // set WiFi server to blocking mode
 void WiFiServer::setBlocking() {
+    // printf("WiFi server is set to blocking mode\r\n");
     _is_blocked = !_is_blocked;
 }
 

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.h
@@ -11,7 +11,7 @@ class WiFiServer : public Server {
         WiFiServer(uint16_t);
         WiFiServer(uint16_t, tProtMode);
         ~WiFiServer();
-        
+
         virtual void begin();
         WiFiClient available(uint8_t* status = NULL);
         virtual int available(int server_fd);

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiServer.h
@@ -10,6 +10,8 @@ class WiFiServer : public Server {
     public:
         WiFiServer(uint16_t);
         WiFiServer(uint16_t, tProtMode);
+        ~WiFiServer();
+        
         virtual void begin();
         WiFiClient available(uint8_t* status = NULL);
         virtual int available(int server_fd);

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiUdp.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiUdp.cpp
@@ -51,7 +51,6 @@ uint8_t WiFiUDP::begin(uint16_t port) {
     if (_sock >= 0) {
         return 1;
     }
-
     return 0;
 }
 
@@ -69,7 +68,6 @@ int WiFiUDP::connect(const char *host, uint16_t port) {
             //printf("[INFO]WiFiUDP.cpp: connect v6 \n\r");
             //printf("[INFO]WiFiUDP.cpp: connect ipv6 %s\n\r", host);
             _sock = clientDrv.startClientV6(host, port, UDP_MODE);
-        } else {
         }
 
         // whether sock is connected

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiUdp.cpp
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiUdp.cpp
@@ -33,6 +33,11 @@ extern "C" {
 /* Constructor */
 WiFiUDP::WiFiUDP() : _sock(-1), _client_sock(-1) {}
 
+/* Destructor */
+WiFiUDP::~WiFiUDP() {
+    stop();
+}
+
 /* Start WiFiUDP socket, listening at local port PORT */
 uint8_t WiFiUDP::begin(uint16_t port) {
     //printf("\n\rWiFiUDP::begin port %d", port);

--- a/Arduino_package/hardware/libraries/WiFi/src/WiFiUdp.h
+++ b/Arduino_package/hardware/libraries/WiFi/src/WiFiUdp.h
@@ -32,6 +32,9 @@ class WiFiUDP : public UDP {
         // Constructor
         WiFiUDP();
 
+        // Destructor
+        ~WiFiUDP();
+
         // initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
         virtual uint8_t begin(uint16_t);
 


### PR DESCRIPTION
- Added destructor for `WiFi()`, `WiFiClient()`, `WiFiSSLClient()`, `WiFiServer()`, `UDP()` Class
- Modified [WiFiWebServer.ino](https://github.com/ambiot/ambd_arduino/compare/dev...S10143806H:ambd_arduino:dev#diff-204ffc57b37a3b16f6a4398a936bb3624e8e2cdf9219ed46f36b3fcf37453be9) `printf()` sequence and structure to ensure the destructor of `WiFiClient()` takes into affect
- Added `printf()` information for future debugging

Verification:
Verified on BW16 with ARDUINO IDE1