### PR TITLE
Support c++ standard lib by default

### DIFF
--- a/Arduino_package/hardware/boards.txt
+++ b/Arduino_package/hardware/boards.txt
@@ -1,7 +1,7 @@
 
 menu.AutoUploadMode=* Auto Upload Mode
 menu.EraseFlash=* Erase All Flash Memory (4MB)
-menu.StdLibInit=* Standard Lib
+#menu.StdLibInit=* Standard Lib
 menu.UploadBaudrate=* Upload Speed
 
 ##############################################################
@@ -42,10 +42,10 @@ Ameba_AMB21_AMB22.menu.EraseFlash.Enable.upload.erase_flash=Enable
 #Ameba_AMB21_AMB22.menu.AutoUploadMode.Enable=Enable
 #Ameba_AMB21_AMB22.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB21_AMB22.menu.StdLibInit.Disable=Disable
-Ameba_AMB21_AMB22.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags}
-Ameba_AMB21_AMB22.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-Ameba_AMB21_AMB22.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags} -DArduino_STD_PRINTF
+#Ameba_AMB21_AMB22.menu.StdLibInit.Disable=Disable
+#Ameba_AMB21_AMB22.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags}
+#Ameba_AMB21_AMB22.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+#Ameba_AMB21_AMB22.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags} -DArduino_STD_PRINTF
 
 Ameba_AMB21_AMB22.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB21_AMB22.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -87,10 +87,10 @@ Ameba_AMB23.menu.EraseFlash.Enable.upload.erase_flash=Enable
 #Ameba_AMB23.menu.AutoUploadMode.Enable=Enable
 #Ameba_AMB23.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB23.menu.StdLibInit.Disable=Disable
-Ameba_AMB23.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags}
-Ameba_AMB23.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-Ameba_AMB23.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags} -DArduino_STD_PRINTF
+#Ameba_AMB23.menu.StdLibInit.Disable=Disable
+#Ameba_AMB23.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags}
+#Ameba_AMB23.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+#Ameba_AMB23.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags} -DArduino_STD_PRINTF
 
 Ameba_AMB23.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB23.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -132,10 +132,10 @@ Ai-Thinker_BW16.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ai-Thinker_BW16.menu.AutoUploadMode.Enable=Enable
 Ai-Thinker_BW16.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ai-Thinker_BW16.menu.StdLibInit.Disable=Disable
-Ai-Thinker_BW16.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags}
-Ai-Thinker_BW16.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-Ai-Thinker_BW16.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags} -DArduino_STD_PRINTF
+#Ai-Thinker_BW16.menu.StdLibInit.Disable=Disable
+#Ai-Thinker_BW16.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags}
+#Ai-Thinker_BW16.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+#Ai-Thinker_BW16.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags} -DArduino_STD_PRINTF
 
 Ai-Thinker_BW16.menu.UploadBaudrate.1500000=1500000
 Ai-Thinker_BW16.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -177,10 +177,10 @@ SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Enable=Enable
 SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable=Disable
-SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags}
-SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags} -DArduino_STD_PRINTF
+#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable=Disable
+#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags}
+#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags} -DArduino_STD_PRINTF
 
 SparkFun_ThingPlus-AWCU488.menu.UploadBaudrate.1500000=1500000
 SparkFun_ThingPlus-AWCU488.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -222,10 +222,10 @@ Ameba_AMB25_AMB26.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ameba_AMB25_AMB26.menu.AutoUploadMode.Enable=Enable
 Ameba_AMB25_AMB26.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB25_AMB26.menu.StdLibInit.Disable=Disable
-Ameba_AMB25_AMB26.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
-Ameba_AMB25_AMB26.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-Ameba_AMB25_AMB26.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
+#Ameba_AMB25_AMB26.menu.StdLibInit.Disable=Disable
+#Ameba_AMB25_AMB26.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
+#Ameba_AMB25_AMB26.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+#Ameba_AMB25_AMB26.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
 
 Ameba_AMB25_AMB26.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB25_AMB26.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -265,10 +265,10 @@ u-blox_NORA-W30.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 u-blox_NORA-W30.menu.AutoUploadMode.Enable=Enable
 u-blox_NORA-W30.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-u-blox_NORA-W30.menu.StdLibInit.Disable=Disable
-u-blox_NORA-W30.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
-u-blox_NORA-W30.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-u-blox_NORA-W30.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
+#u-blox_NORA-W30.menu.StdLibInit.Disable=Disable
+#u-blox_NORA-W30.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
+#u-blox_NORA-W30.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+#u-blox_NORA-W30.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
 
 u-blox_NORA-W30.menu.UploadBaudrate.921600=921600
 u-blox_NORA-W30.menu.UploadBaudrate.921600.upload.speed=921600

--- a/Arduino_package/hardware/boards.txt
+++ b/Arduino_package/hardware/boards.txt
@@ -1,7 +1,7 @@
 
 menu.AutoUploadMode=* Auto Upload Mode
 menu.EraseFlash=* Erase All Flash Memory (4MB)
-#menu.StdLibInit=* Standard Lib
+menu.StdLibInit=* Standard Lib
 menu.UploadBaudrate=* Upload Speed
 
 ##############################################################
@@ -18,7 +18,7 @@ Ameba_AMB21_AMB22.build.f_cpu=200000000L
 Ameba_AMB21_AMB22.build.usb_product="AMB21"
 Ameba_AMB21_AMB22.build.board=AMEBA
 Ameba_AMB21_AMB22.build.core=ambd
-Ameba_AMB21_AMB22.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags}
+Ameba_AMB21_AMB22.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB21_AMB22.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB21_AMB22.build.variant=rtl8722dm
 
@@ -42,10 +42,10 @@ Ameba_AMB21_AMB22.menu.EraseFlash.Enable.upload.erase_flash=Enable
 #Ameba_AMB21_AMB22.menu.AutoUploadMode.Enable=Enable
 #Ameba_AMB21_AMB22.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-#Ameba_AMB21_AMB22.menu.StdLibInit.Disable=Disable
-#Ameba_AMB21_AMB22.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags}
-#Ameba_AMB21_AMB22.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-#Ameba_AMB21_AMB22.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB21_AMB22.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+Ameba_AMB21_AMB22.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB21_AMB22.menu.StdLibInit.Disable=Disable
+Ameba_AMB21_AMB22.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM {build.usb_flags}
 
 Ameba_AMB21_AMB22.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB21_AMB22.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -63,7 +63,7 @@ Ameba_AMB23.build.f_cpu=200000000L
 Ameba_AMB23.build.usb_product="AMB23"
 Ameba_AMB23.build.board=AMEBA
 Ameba_AMB23.build.core=ambd
-Ameba_AMB23.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags}
+Ameba_AMB23.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB23.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB23.build.variant=rtl8722dm_mini
 
@@ -87,10 +87,11 @@ Ameba_AMB23.menu.EraseFlash.Enable.upload.erase_flash=Enable
 #Ameba_AMB23.menu.AutoUploadMode.Enable=Enable
 #Ameba_AMB23.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-#Ameba_AMB23.menu.StdLibInit.Disable=Disable
-#Ameba_AMB23.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags}
-#Ameba_AMB23.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-#Ameba_AMB23.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB23.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+Ameba_AMB23.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB23.menu.StdLibInit.Disable=Disable
+Ameba_AMB23.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8722DM_MINI {build.usb_flags}
+
 
 Ameba_AMB23.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB23.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -108,7 +109,7 @@ Ai-Thinker_BW16.build.f_cpu=200000000L
 Ai-Thinker_BW16.build.usb_product="BW16"
 Ai-Thinker_BW16.build.board=AMEBA
 Ai-Thinker_BW16.build.core=ambd
-Ai-Thinker_BW16.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags}
+Ai-Thinker_BW16.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags} -DArduino_STD_PRINTF
 Ai-Thinker_BW16.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ai-Thinker_BW16.build.variant=rtl8720dn_bw16
 
@@ -132,10 +133,10 @@ Ai-Thinker_BW16.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ai-Thinker_BW16.menu.AutoUploadMode.Enable=Enable
 Ai-Thinker_BW16.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-#Ai-Thinker_BW16.menu.StdLibInit.Disable=Disable
-#Ai-Thinker_BW16.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags}
-#Ai-Thinker_BW16.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-#Ai-Thinker_BW16.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags} -DArduino_STD_PRINTF
+Ai-Thinker_BW16.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+Ai-Thinker_BW16.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags} -DArduino_STD_PRINTF
+Ai-Thinker_BW16.menu.StdLibInit.Disable=Disable
+Ai-Thinker_BW16.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DN_BW16 {build.usb_flags}
 
 Ai-Thinker_BW16.menu.UploadBaudrate.1500000=1500000
 Ai-Thinker_BW16.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -153,7 +154,7 @@ SparkFun_ThingPlus-AWCU488.build.f_cpu=200000000L
 SparkFun_ThingPlus-AWCU488.build.usb_product="AW-CU488_ThingPlus"
 SparkFun_ThingPlus-AWCU488.build.board=AMEBA
 SparkFun_ThingPlus-AWCU488.build.core=ambd
-SparkFun_ThingPlus-AWCU488.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags}
+SparkFun_ThingPlus-AWCU488.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags} -DArduino_STD_PRINTF
 SparkFun_ThingPlus-AWCU488.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 SparkFun_ThingPlus-AWCU488.build.variant=sparkfun_thingplus-awcu488
 
@@ -177,10 +178,10 @@ SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Enable=Enable
 SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable=Disable
-#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags}
-#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-#SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags} -DArduino_STD_PRINTF
+SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags} -DArduino_STD_PRINTF
+SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable=Disable
+SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8721DM {build.usb_flags}
 
 SparkFun_ThingPlus-AWCU488.menu.UploadBaudrate.1500000=1500000
 SparkFun_ThingPlus-AWCU488.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -198,7 +199,7 @@ Ameba_AMB25_AMB26.build.f_cpu=200000000L
 Ameba_AMB25_AMB26.build.usb_product="AMB25/AMB26"
 Ameba_AMB25_AMB26.build.board=AMEBA
 Ameba_AMB25_AMB26.build.core=ambd
-Ameba_AMB25_AMB26.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
+Ameba_AMB25_AMB26.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB25_AMB26.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB25_AMB26.build.variant=ameba_amb25_amb26
 
@@ -222,10 +223,10 @@ Ameba_AMB25_AMB26.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ameba_AMB25_AMB26.menu.AutoUploadMode.Enable=Enable
 Ameba_AMB25_AMB26.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-#Ameba_AMB25_AMB26.menu.StdLibInit.Disable=Disable
-#Ameba_AMB25_AMB26.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
-#Ameba_AMB25_AMB26.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-#Ameba_AMB25_AMB26.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB25_AMB26.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+Ameba_AMB25_AMB26.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB25_AMB26.menu.StdLibInit.Disable=Disable
+Ameba_AMB25_AMB26.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
 
 Ameba_AMB25_AMB26.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB25_AMB26.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -241,7 +242,7 @@ u-blox_NORA-W30.build.f_cpu=200000000L
 u-blox_NORA-W30.build.usb_product="u-blox_NORA-W30"
 u-blox_NORA-W30.build.board=AMEBA
 u-blox_NORA-W30.build.core=ambd
-u-blox_NORA-W30.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
+u-blox_NORA-W30.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
 u-blox_NORA-W30.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 u-blox_NORA-W30.build.variant=u-blox_NORA-W30
 
@@ -265,10 +266,10 @@ u-blox_NORA-W30.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 u-blox_NORA-W30.menu.AutoUploadMode.Enable=Enable
 u-blox_NORA-W30.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-#u-blox_NORA-W30.menu.StdLibInit.Disable=Disable
-#u-blox_NORA-W30.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
-#u-blox_NORA-W30.menu.StdLibInit.Enable=Arduino_STD_PRINTF
-#u-blox_NORA-W30.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
+u-blox_NORA-W30.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+u-blox_NORA-W30.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags} -DArduino_STD_PRINTF
+u-blox_NORA-W30.menu.StdLibInit.Disable=Disable
+u-blox_NORA-W30.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_RTL8720DF {build.usb_flags}
 
 u-blox_NORA-W30.menu.UploadBaudrate.921600=921600
 u-blox_NORA-W30.menu.UploadBaudrate.921600.upload.speed=921600

--- a/Arduino_package/hardware/cores/ambd/Arduino.h
+++ b/Arduino_package/hardware/cores/ambd/Arduino.h
@@ -29,7 +29,7 @@
 #include "binary.h"
 
 //#define Arduino_STD_PRINTF
-// #ifdef Arduino_STD_PRINTF
+#ifdef Arduino_STD_PRINTF
 #define STD_PRINTF
 
 #ifdef __cplusplus
@@ -37,7 +37,7 @@
 #endif // __cplusplus
 
 #include <stdio.h>
-// #endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/Arduino_package/hardware/cores/ambd/Arduino.h
+++ b/Arduino_package/hardware/cores/ambd/Arduino.h
@@ -29,14 +29,15 @@
 #include "binary.h"
 
 //#define Arduino_STD_PRINTF
-#ifdef Arduino_STD_PRINTF
+// #ifdef Arduino_STD_PRINTF
 #define STD_PRINTF
+
 #ifdef __cplusplus
 #include <string>
 #endif // __cplusplus
 
 #include <stdio.h>
-#endif
+// #endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/Arduino_package/hardware/cores/ambd/ard_socket.c
+++ b/Arduino_package/hardware/cores/ambd/ard_socket.c
@@ -394,7 +394,7 @@ int send_data(int sock, const uint8_t *data, uint16_t len, int flag) {
     int total_count = len;
     int err;
 
-    printf("len %d\r\n", len);
+    // printf("len %d\r\n", len);
     while (retry) {
         int count = TCP_MSS;
         retry--;
@@ -412,11 +412,11 @@ int send_data(int sock, const uint8_t *data, uint16_t len, int flag) {
                 retry = 0;
             }
         } else {
-            printf("write count = %d\r\n",ret);
+            // printf("write count = %d\r\n",ret);
             len -= ret;
             data += ret;
-            printf("len %d\r\n", len);
-            printf("data %d\r\n", data);
+            // printf("len %d\r\n", len);
+            // printf("data %d\r\n", data);
             // finished data transmission
             if(len == 0) { 
                 ret = total_count;


### PR DESCRIPTION
- support standard lib `<string>` by default
- disable Standard Lib menu selection in Arduino IDE
- remove `printf()` debug message in `ard_socket.c`

Verification:
Verified on Arduino IDE1&2 with Ameba D series: AMB21/22/23/25/26 BW16/BW16TypeC AWCU488 and u-blox NORA-W30