### PR TITLE
Support c++ standard lib by default

### DIFF
--- a/Arduino_package/hardware/boards.txt
+++ b/Arduino_package/hardware/boards.txt
@@ -18,7 +18,7 @@ Ameba_AMB21_AMB22.build.f_cpu=200000000L
 Ameba_AMB21_AMB22.build.usb_product="AMB21"
 Ameba_AMB21_AMB22.build.board=AMEBA
 Ameba_AMB21_AMB22.build.core=ambd
-Ameba_AMB21_AMB22.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB21_AMB22 {build.usb_flags}
+Ameba_AMB21_AMB22.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB21_AMB22 {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB21_AMB22.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB21_AMB22.build.variant=rtl8722dm
 
@@ -42,10 +42,10 @@ Ameba_AMB21_AMB22.menu.EraseFlash.Enable.upload.erase_flash=Enable
 #Ameba_AMB21_AMB22.menu.AutoUploadMode.Enable=Enable
 #Ameba_AMB21_AMB22.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB21_AMB22.menu.StdLibInit.Disable=Disable
-Ameba_AMB21_AMB22.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB21_AMB22 {build.usb_flags}
 Ameba_AMB21_AMB22.menu.StdLibInit.Enable=Arduino_STD_PRINTF
 Ameba_AMB21_AMB22.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB21_AMB22 {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB21_AMB22.menu.StdLibInit.Disable=Disable
+Ameba_AMB21_AMB22.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB21_AMB22 {build.usb_flags}
 
 Ameba_AMB21_AMB22.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB21_AMB22.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -63,7 +63,7 @@ Ameba_AMB23.build.f_cpu=200000000L
 Ameba_AMB23.build.usb_product="AMB23"
 Ameba_AMB23.build.board=AMEBA
 Ameba_AMB23.build.core=ambd
-Ameba_AMB23.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB23 {build.usb_flags}
+Ameba_AMB23.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB23 {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB23.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB23.build.variant=rtl8722dm_mini
 
@@ -87,10 +87,10 @@ Ameba_AMB23.menu.EraseFlash.Enable.upload.erase_flash=Enable
 #Ameba_AMB23.menu.AutoUploadMode.Enable=Enable
 #Ameba_AMB23.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB23.menu.StdLibInit.Disable=Disable
-Ameba_AMB23.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB23 {build.usb_flags}
 Ameba_AMB23.menu.StdLibInit.Enable=Arduino_STD_PRINTF
 Ameba_AMB23.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB23 {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB23.menu.StdLibInit.Disable=Disable
+Ameba_AMB23.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB23 {build.usb_flags}
 
 Ameba_AMB23.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB23.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -108,7 +108,7 @@ Ai-Thinker_BW16.build.f_cpu=200000000L
 Ai-Thinker_BW16.build.usb_product="BW16"
 Ai-Thinker_BW16.build.board=AMEBA
 Ai-Thinker_BW16.build.core=ambd
-Ai-Thinker_BW16.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AITHINKER_BW16 {build.usb_flags}
+Ai-Thinker_BW16.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AITHINKER_BW16 {build.usb_flags} -DArduino_STD_PRINTF
 Ai-Thinker_BW16.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ai-Thinker_BW16.build.variant=rtl8720dn_bw16
 
@@ -132,10 +132,10 @@ Ai-Thinker_BW16.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ai-Thinker_BW16.menu.AutoUploadMode.Enable=Enable
 Ai-Thinker_BW16.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ai-Thinker_BW16.menu.StdLibInit.Disable=Disable
-Ai-Thinker_BW16.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AITHINKER_BW16 {build.usb_flags}
 Ai-Thinker_BW16.menu.StdLibInit.Enable=Arduino_STD_PRINTF
 Ai-Thinker_BW16.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AITHINKER_BW16 {build.usb_flags} -DArduino_STD_PRINTF
+Ai-Thinker_BW16.menu.StdLibInit.Disable=Disable
+Ai-Thinker_BW16.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AITHINKER_BW16 {build.usb_flags}
 
 Ai-Thinker_BW16.menu.UploadBaudrate.1500000=1500000
 Ai-Thinker_BW16.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -153,7 +153,7 @@ SparkFun_ThingPlus-AWCU488.build.f_cpu=200000000L
 SparkFun_ThingPlus-AWCU488.build.usb_product="AW-CU488_ThingPlus"
 SparkFun_ThingPlus-AWCU488.build.board=AMEBA
 SparkFun_ThingPlus-AWCU488.build.core=ambd
-SparkFun_ThingPlus-AWCU488.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_SPARKFUN_AWCU488 {build.usb_flags}
+SparkFun_ThingPlus-AWCU488.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_SPARKFUN_AWCU488 {build.usb_flags} -DArduino_STD_PRINTF
 SparkFun_ThingPlus-AWCU488.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 SparkFun_ThingPlus-AWCU488.build.variant=sparkfun_thingplus-awcu488
 
@@ -177,10 +177,10 @@ SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Enable=Enable
 SparkFun_ThingPlus-AWCU488.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable=Disable
-SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_SPARKFUN_AWCU488 {build.usb_flags}
 SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable=Arduino_STD_PRINTF
 SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_SPARKFUN_AWCU488 {build.usb_flags} -DArduino_STD_PRINTF
+SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable=Disable
+SparkFun_ThingPlus-AWCU488.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_SPARKFUN_AWCU488 {build.usb_flags}
 
 SparkFun_ThingPlus-AWCU488.menu.UploadBaudrate.1500000=1500000
 SparkFun_ThingPlus-AWCU488.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -198,7 +198,7 @@ Ameba_AMB25.build.f_cpu=200000000L
 Ameba_AMB25.build.usb_product="AMB25"
 Ameba_AMB25.build.board=AMEBA
 Ameba_AMB25.build.core=ambd
-Ameba_AMB25.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB25 {build.usb_flags}
+Ameba_AMB25.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB25 {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB25.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB25.build.variant=ameba_amb25_amb26
 
@@ -222,10 +222,10 @@ Ameba_AMB25.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ameba_AMB25.menu.AutoUploadMode.Enable=Enable
 Ameba_AMB25.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB25.menu.StdLibInit.Disable=Disable
-Ameba_AMB25.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB25 {build.usb_flags}
 Ameba_AMB25.menu.StdLibInit.Enable=Arduino_STD_PRINTF
 Ameba_AMB25.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB25 {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB25.menu.StdLibInit.Disable=Disable
+Ameba_AMB25.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB25 {build.usb_flags}
 
 Ameba_AMB25.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB25.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -243,7 +243,7 @@ Ameba_AMB26.build.f_cpu=200000000L
 Ameba_AMB26.build.usb_product="AMB26"
 Ameba_AMB26.build.board=AMEBA
 Ameba_AMB26.build.core=ambd
-Ameba_AMB26.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB26 {build.usb_flags}
+Ameba_AMB26.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB26 {build.usb_flags} -DArduino_STD_PRINTF
 Ameba_AMB26.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 Ameba_AMB26.build.variant=ameba_amb25_amb26
 
@@ -267,10 +267,10 @@ Ameba_AMB26.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 Ameba_AMB26.menu.AutoUploadMode.Enable=Enable
 Ameba_AMB26.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
-Ameba_AMB26.menu.StdLibInit.Disable=Disable
-Ameba_AMB26.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB26 {build.usb_flags}
 Ameba_AMB26.menu.StdLibInit.Enable=Arduino_STD_PRINTF
 Ameba_AMB26.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB26 {build.usb_flags} -DArduino_STD_PRINTF
+Ameba_AMB26.menu.StdLibInit.Disable=Disable
+Ameba_AMB26.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_AMB26 {build.usb_flags}
 
 Ameba_AMB26.menu.UploadBaudrate.1500000=1500000
 Ameba_AMB26.menu.UploadBaudrate.1500000.upload.speed=1500000
@@ -286,7 +286,7 @@ u-blox_NORA-W30.build.f_cpu=200000000L
 u-blox_NORA-W30.build.usb_product="u-blox_NORA-W30"
 u-blox_NORA-W30.build.board=AMEBA
 u-blox_NORA-W30.build.core=ambd
-u-blox_NORA-W30.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_UBLOX_NORAW30 {build.usb_flags}
+u-blox_NORA-W30.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_UBLOX_NORAW30 {build.usb_flags} -DArduino_STD_PRINTF
 u-blox_NORA-W30.build.ldscript=linker_scripts/gcc/amebad_img2_is_arduino.ld
 u-blox_NORA-W30.build.variant=u-blox_NORA-W30
 
@@ -310,6 +310,8 @@ u-blox_NORA-W30.menu.AutoUploadMode.Disable.upload.auto_mode=Disable
 u-blox_NORA-W30.menu.AutoUploadMode.Enable=Enable
 u-blox_NORA-W30.menu.AutoUploadMode.Enable.upload.auto_mode=Enable
 
+u-blox_NORA-W30.menu.StdLibInit.Enable=Arduino_STD_PRINTF
+u-blox_NORA-W30.menu.StdLibInit.Enable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_UBLOX_NORAW30 {build.usb_flags} -DArduino_STD_PRINTF
 u-blox_NORA-W30.menu.StdLibInit.Disable=Disable
 u-blox_NORA-W30.menu.StdLibInit.Disable.build.extra_flags=-mthumb -DRTL8722DM -DBOARD_UBLOX_NORAW30 {build.usb_flags}
 u-blox_NORA-W30.menu.StdLibInit.Enable=Arduino_STD_PRINTF

--- a/Arduino_package/hardware/cores/ambd/Arduino.h
+++ b/Arduino_package/hardware/cores/ambd/Arduino.h
@@ -36,10 +36,14 @@
 #ifdef __cplusplus
 #include <string>
 #endif // __cplusplus
-#include <stdio.h>
-#endif // Arduino_STD_PRINTF
+
+// #include <stdio.h>
+#endif
 
 #ifdef __cplusplus
+
+#include <stdio.h> // include before callig min/max in wiring_constants.h
+
 extern "C" {
 #endif // __cplusplus
 

--- a/Arduino_package/hardware/cores/ambd/Arduino.h
+++ b/Arduino_package/hardware/cores/ambd/Arduino.h
@@ -30,20 +30,16 @@
 
 #define AMEBA_ARDUINO_Pin_Mapping_Check
 
-//#define Arduino_STD_PRINTF
 #ifdef Arduino_STD_PRINTF
 #define STD_PRINTF
 #ifdef __cplusplus
 #include <string>
 #endif // __cplusplus
-
 // #include <stdio.h>
-#endif
+#endif // Arduino_STD_PRINTF
 
 #ifdef __cplusplus
-
 #include <stdio.h> // include before callig min/max in wiring_constants.h
-
 extern "C" {
 #endif // __cplusplus
 

--- a/Arduino_package/hardware/cores/ambd/ard_socket.c
+++ b/Arduino_package/hardware/cores/ambd/ard_socket.c
@@ -395,7 +395,7 @@ int send_data(int sock, const uint8_t *data, uint16_t len, int flag) {
     int err;
 
     // printf("len %d\r\n", len);
-    while(retry) {
+    while (retry) {
         int count = TCP_MSS;
         retry--;
         if (count > len) {
@@ -418,7 +418,7 @@ int send_data(int sock, const uint8_t *data, uint16_t len, int flag) {
             // printf("len %d\r\n", len);
             // printf("data %d\r\n", data);
             // finished data transmission
-            if(len == 0) { 
+            if (len == 0) { 
                 ret = total_count;
                 retry = 0;
                 break;

--- a/Arduino_package/hardware/cores/ambd/ard_socket.c
+++ b/Arduino_package/hardware/cores/ambd/ard_socket.c
@@ -394,8 +394,8 @@ int send_data(int sock, const uint8_t *data, uint16_t len, int flag) {
     int total_count = len;
     int err;
 
-    printf("len %d\r\n", len);
-    while (retry) {
+    // printf("len %d\r\n", len);
+    while(retry) {
         int count = TCP_MSS;
         retry--;
         if (count > len) {
@@ -412,11 +412,11 @@ int send_data(int sock, const uint8_t *data, uint16_t len, int flag) {
                 retry = 0;
             }
         } else {
-            printf("write count = %d\r\n",ret);
+            // printf("write count = %d\r\n",ret);
             len -= ret;
             data += ret;
-            printf("len %d\r\n", len);
-            printf("data %d\r\n", data);
+            // printf("len %d\r\n", len);
+            // printf("data %d\r\n", data);
             // finished data transmission
             if(len == 0) { 
                 ret = total_count;

--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -71,13 +71,24 @@ enum BitOrder {
 #undef abs
 #endif // abs
 
-#ifndef min
-#define min(a,b) ((a)<(b)?(a):(b))
-#endif // min
+// <<<<<<<<<<<<<<<<<<<<<<
+// #ifndef min
+// #define min(a,b) ((a)<(b)?(a):(b))
+// #endif // min
 
-#ifndef max
-#define max(a,b) ((a)>(b)?(a):(b))
-#endif // max
+// #ifndef max
+// #define max(a,b) ((a)>(b)?(a):(b))
+// #endif // max
+// >>>>>>>>>>>>>>>>>>>>>>
+#ifdef min 
+#undef min // undefine std lib min function
+#define min(a,b) ((a)<(b)?(a):(b))
+#endif 
+
+#ifdef max
+#undef max // undefine std lib max function
+#define max(a,b) ((a)<(b)?(a):(b))
+#endif 
 
 #define abs(x) ((x)>0?(x):-(x))
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))

--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -80,6 +80,8 @@ enum BitOrder {
 // #define max(a,b) ((a)>(b)?(a):(b))
 // #endif // max
 // >>>>>>>>>>>>>>>>>>>>>>
+#ifndef Arduino_STD_PRINTF
+
 #ifdef min 
 #undef min // undefine std lib min function
 #define min(a,b) ((a)<(b)?(a):(b))
@@ -89,6 +91,8 @@ enum BitOrder {
 #undef max // undefine std lib max function
 #define max(a,b) ((a)<(b)?(a):(b))
 #endif 
+
+#endif
 
 #define abs(x) ((x)>0?(x):-(x))
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))

--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -72,12 +72,10 @@ enum BitOrder {
 #endif // abs
 
 #ifndef Arduino_STD_PRINTF
-#ifdef min 
-#undef min // undefine std lib min function
+#ifndef min 
 #define min(a,b) ((a)<(b)?(a):(b))
 #endif // min
-#ifdef max
-#undef max // undefine std lib max function
+#ifndef max
 #define max(a,b) ((a)>(b)?(a):(b))
 #endif // max
 #endif // Arduino_STD_PRINTF

--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -78,7 +78,7 @@ enum BitOrder {
 #endif // min
 #ifdef max
 #undef max // undefine std lib max function
-#define max(a,b) ((a)<(b)?(a):(b))
+#define max(a,b) ((a)>(b)?(a):(b))
 #endif // max
 #endif // Arduino_STD_PRINTF
 

--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -71,26 +71,16 @@ enum BitOrder {
 #undef abs
 #endif // abs
 
-// <<<<<<<<<<<<<<<<<<<<<<
-// #ifndef min
-// #define min(a,b) ((a)<(b)?(a):(b))
-// #endif // min
-
-// #ifndef max
-// #define max(a,b) ((a)>(b)?(a):(b))
-// #endif // max
-// >>>>>>>>>>>>>>>>>>>>>>
 #ifndef Arduino_STD_PRINTF
 #ifdef min 
 #undef min // undefine std lib min function
 #define min(a,b) ((a)<(b)?(a):(b))
-#endif 
-
+#endif // min
 #ifdef max
 #undef max // undefine std lib max function
 #define max(a,b) ((a)<(b)?(a):(b))
-#endif 
-#endif
+#endif // max
+#endif // Arduino_STD_PRINTF
 
 #define abs(x) ((x)>0?(x):-(x))
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))

--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -81,7 +81,6 @@ enum BitOrder {
 // #endif // max
 // >>>>>>>>>>>>>>>>>>>>>>
 #ifndef Arduino_STD_PRINTF
-
 #ifdef min 
 #undef min // undefine std lib min function
 #define min(a,b) ((a)<(b)?(a):(b))
@@ -91,7 +90,6 @@ enum BitOrder {
 #undef max // undefine std lib max function
 #define max(a,b) ((a)<(b)?(a):(b))
 #endif 
-
 #endif
 
 #define abs(x) ((x)>0?(x):-(x))


### PR DESCRIPTION
- support standard lib `<string>` by default, default enable `Arduino_STD_PRINTF` that allows `printf()` and `_rtl_printf()` simultaneously
- include `-DArduino_STD_PRINTF` in extra-flag
- modify the define sequence of `min()` `max()` in `wiring_constants.h` to remove compilation error
- ensures downward compatibility
- remove extra `printf()` debug message in `ard_socket.c`

Verification:
Verified on Arduino IDE1&2 with Ameba D series: AMB21/22/23/25/26 BW16/BW16TypeC AWCU488 and u-blox NORA-W30