### PR TITLE
Fix undefined behavior when doing pin_check

### DIFF
--- a/Arduino_package/hardware/cores/ambd/amb_ard_pin_check.c
+++ b/Arduino_package/hardware/cores/ambd/amb_ard_pin_check.c
@@ -95,7 +95,10 @@ void amb_ard_pin_check_fun(int pin, uint32_t pin_fun) {
             printf("Error %s. Incorrect pin_fun input!!! \n\r", __FUNCTION__);
     }
 
-    while ((g_APinDescription[pin].ulPinAttribute & pin_fun) != pin_fun) {
+    uint32_t check_bit = (g_APinDescription[pin].ulPinAttribute & pin_fun); 
+
+    while (check_bit != pin_fun) 
+    {
         printf("Error %s. %s is not supported by the pin: %d !!! \n\r", __FUNCTION__, pin_fun_name, pin);
         printf("Please check if pin or board is correct \n\r");
         delay(5000);


### PR DESCRIPTION
I2C Scanner hangs when reset for AMB26. Fix for 3.1.7-build20230921.