### PR TITLE
Solve SPI compile issues when Arduino_STD_PRINTF enabled

### DIFF
--- a/Arduino_package/hardware/cores/ambd/wiring_constants.h
+++ b/Arduino_package/hardware/cores/ambd/wiring_constants.h
@@ -20,37 +20,37 @@
 #define _WIRING_CONSTANTS_
 
 #ifdef __cplusplus
-extern "C"{
-#endif // __cplusplus
+extern "C" {
+#endif    // __cplusplus
 
 #define HIGH 0x1
 #define LOW  0x0
 
-// 0X00 NA 
-#define INPUT_PULLDOWN      0x01
-#define INPUT               INPUT_PULLDOWN
-#define OUTPUT              0x02
-#define INPUT_PULLUP        0x03
-#define INPUT_PULLNONE      0x04
-#define OUTPUT_OPENDRAIN    0x05
-#define INPUT_IRQ_FALL      0x06
-#define INPUT_IRQ_RISE      0x07
-#define INPUT_IRQ_LOW       0x08
-#define INPUT_IRQ_HIGH      0x09
-#define INPUT_IRQ_CHANGE    0x0a
+// 0X00 NA
+#define INPUT_PULLDOWN   0x01
+#define INPUT            INPUT_PULLDOWN
+#define OUTPUT           0x02
+#define INPUT_PULLUP     0x03
+#define INPUT_PULLNONE   0x04
+#define OUTPUT_OPENDRAIN 0x05
+#define INPUT_IRQ_FALL   0x06
+#define INPUT_IRQ_RISE   0x07
+#define INPUT_IRQ_LOW    0x08
+#define INPUT_IRQ_HIGH   0x09
+#define INPUT_IRQ_CHANGE 0x0a
 
-#define true                0x1
-#define false               0x0
+#define true  0x1
+#define false 0x0
 
-#define PI                  3.1415926535897932384626433832795
-#define HALF_PI             1.5707963267948966192313216916398
-#define TWO_PI              6.283185307179586476925286766559
-#define DEG_TO_RAD          0.017453292519943295769236907684886
-#define RAD_TO_DEG          57.295779513082320876798154814105
-#define EULER               2.718281828459045235360287471352
+#define PI         3.1415926535897932384626433832795
+#define HALF_PI    1.5707963267948966192313216916398
+#define TWO_PI     6.283185307179586476925286766559
+#define DEG_TO_RAD 0.017453292519943295769236907684886
+#define RAD_TO_DEG 57.295779513082320876798154814105
+#define EULER      2.718281828459045235360287471352
 
-#define SERIAL              0x0
-#define DISPLAY             0x1
+#define SERIAL  0x0
+#define DISPLAY 0x1
 
 enum BitOrder {
     LSBFIRST = 0,
@@ -59,46 +59,44 @@ enum BitOrder {
 
 //      LOW 0
 //      HIGH 1
-#define CHANGE              2
-#define FALLING             3
-#define RISING              4
+#define CHANGE  2
+#define FALLING 3
+#define RISING  4
 
-#define DEFAULT             1
-#define EXTERNAL            0
+#define DEFAULT  1
+#define EXTERNAL 0
 
 // undefine stdlib's abs if encountered
 #ifdef abs
 #undef abs
-#endif // abs
+#endif    // abs
 
-#ifndef Arduino_STD_PRINTF
-#ifndef min 
-#define min(a,b) ((a)<(b)?(a):(b))
-#endif // min
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif    // min
 #ifndef max
-#define max(a,b) ((a)>(b)?(a):(b))
-#endif // max
-#endif // Arduino_STD_PRINTF
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif    // max
 
-#define abs(x) ((x)>0?(x):-(x))
-#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
-#define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-#define radians(deg) ((deg)*DEG_TO_RAD)
-#define degrees(rad) ((rad)*RAD_TO_DEG)
-#define sq(x) ((x)*(x))
+#define abs(x)                    ((x) > 0 ? (x) : -(x))
+#define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
+#define round(x)                  ((x) >= 0 ? (long)((x) + 0.5) : (long)((x)-0.5))
+#define radians(deg)              ((deg) * DEG_TO_RAD)
+#define degrees(rad)              ((rad) * RAD_TO_DEG)
+#define sq(x)                     ((x) * (x))
 
 extern uint32_t ulSetInterruptMaskFromISR(void);
 extern void vClearInterruptMaskFromISR(uint32_t ulNewMask);
 
-#define interrupts() vClearInterruptMaskFromISR(0)
+#define interrupts()   vClearInterruptMaskFromISR(0)
 #define noInterrupts() ulSetInterruptMaskFromISR()
 
-#define lowByte(w) ((uint8_t) ((w) & 0xff))
-#define highByte(w) ((uint8_t) ((w) >> 8))
+#define lowByte(w)  ((uint8_t)((w) & 0xff))
+#define highByte(w) ((uint8_t)((w) >> 8))
 
-#define bitRead(value, bit) (((value) >> (bit)) & 0x01)
-#define bitSet(value, bit) ((value) |= (1UL << (bit)))
-#define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
+#define bitRead(value, bit)            (((value) >> (bit)) & 0x01)
+#define bitSet(value, bit)             ((value) |= (1UL << (bit)))
+#define bitClear(value, bit)           ((value) &= ~(1UL << (bit)))
 #define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
 
 typedef unsigned int word;
@@ -106,12 +104,12 @@ typedef unsigned int word;
 #define bit(b) (1UL << (b))
 
 // TODO: to be checked
-typedef uint8_t boolean ;
-typedef uint8_t byte ;
+typedef uint8_t boolean;
+typedef uint8_t byte;
 
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}    // extern "C"
+#endif    // __cplusplus
 
 #endif /* _WIRING_CONSTANTS_ */


### PR DESCRIPTION

## Description of Change
- Modify wiring_constant.h to resolve min not declared when Arduino_STD_PRINTF is enabled

## Tests and Environments 
- BW16
- ambd_arduino V3.1.7
- Arduino IDE 2.3.2
- Windows 10

## Remark related links
- https://github.com/ambiot/ambd_arduino/issues/231
