### PR TITLE
Updating dataMode in beginTransaction()

### DIFF
--- a/Arduino_package/hardware/libraries/SPI/src/SPI.cpp
+++ b/Arduino_package/hardware/libraries/SPI/src/SPI.cpp
@@ -53,6 +53,7 @@ SPIClass::SPIClass(void *pSpiObj, int mosi, int miso, int clk, int ss) {
 void SPIClass::beginTransaction(uint8_t pin, SPISettings settings) {
     (void)pin;
     bitOrder = settings._bitOrder;
+    dataMode = settings._dataMode;
     spi_format((spi_t *)pSpiMaster, dataBits, dataMode, 0);
     spi_frequency((spi_t *)pSpiMaster, settings._clock);
 


### PR DESCRIPTION
## Description of Change
Arduino libraries should update SPI settings when beginTransaction() is called with a complete struct of SPISettings is passed in as an argument.

- Feature: SPI
- API Updates: beginTransaction()

## Tests and Environments 
- Hardware: Sparkfun NoraW306
- ambd_arduino V3.1.8
- Arduino IDE 2.3.2
- Windows 11

This PR fixes issue #239 
