### PR TITLE
Remove disabling of SPI in show()

### DIFF
--- a/Arduino_package/hardware/libraries/WS2812B/src/WS2812B.cpp
+++ b/Arduino_package/hardware/libraries/WS2812B/src/WS2812B.cpp
@@ -87,9 +87,6 @@ void WS2812B::show(void) {
     }
     //Add a dummy bytes to ensure that the last bit of the data is sent out
     spi_slave_write((spi_t *)pSpiMaster, 0);
-    //Ensure that Tx FIFO is empty before disable SPI
-    while (!(HAL_READ32(spi_addr,0x28) & 0x04));
-    spi_free((spi_t *)pSpiMaster);
 }
 
 void WS2812B::clear(void) {


### PR DESCRIPTION
- removed disabling of SPI in show()
- Note, we need SPI to stay open for any repeat calls to show().

-----------
## Description of Change
This allows the user to call show() more than once, allowing the WS2812B LED to change colors throughout the sketch.

- Feature: multiple calls to show() to adjust WS2812B LED
- API Updates: show()

## Tests and Environments 
- SparkFun Thing Plus NORAW306
- ambd_arduino V3.1.8
- Arduino IDE 2.3.2
- Windows 11

## Remark related links
- fixes issue #241 
