### PR TITLE
fix SoftwareSerial::setBufferSize realloc

### DIFF
--- a/Arduino_package/hardware/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/Arduino_package/hardware/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -209,8 +209,10 @@ int SoftwareSerial::peek() {
 /* Extend API provide by RTK */
 void SoftwareSerial::setBufferSize(uint32_t buffer_size) {
     if (_receive_buffer != NULL) {
-        if (realloc(_receive_buffer, buffer_size) != NULL) {
+        char * rebuffer = (char *)realloc(_receive_buffer, buffer_size);
+        if (rebuffer != NULL) {
             _receive_buffer_size = buffer_size;
+            _receive_buffer = rebuffer;
         }
     }
 }


### PR DESCRIPTION
## Description of Change
fix SoftwareSerial::setBufferSize use realloc without change _receive_buffer point.

## Tests and Environments 
- BW16
- ambd_arduino V3.1.7
- Arduino IDE 2.3.2
- Windows 11
